### PR TITLE
refactor: modern responsive header and theme

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -5,8 +5,15 @@ body{margin:0;min-height:100vh;text-rendering:optimizeLegibility}
 img,video{max-width:100%;height:auto;display:block}
 button,input,textarea,select{font:inherit;color:inherit}
 a{color:inherit;text-decoration:none}
-:focus-visible{outline:2px solid var(--accent-400);outline-offset:3px}
+:focus-visible{outline:2px solid var(--primary);outline-offset:3px}
 .sr-only{position:absolute;left:-9999px}
+
+@media (pointer:fine){
+  body,button,a,input,textarea,select{cursor:none}
+}
+
+::selection{background:var(--brand-rose-300);color:var(--brand-emerald-900)}
+html[data-theme="light"] ::selection{background:#A8C3BC;color:#2E2E2E}
 
 /* === Design tokens === */
 :root{
@@ -17,10 +24,8 @@ a{color:inherit;text-decoration:none}
   --brand-emerald-900:#003332;
   --brand-accent-500:#FF8128;
 
-  --emerald-600:#126B5B; --emerald-700:var(--brand-emerald-700);
-  --bg: var(--brand-emerald-900); --fg:#EAF2EF; --card:#0B2E2A; --border:#12433A;
-  --primary: var(--emerald-600); --primary-strong: var(--emerald-700);
-  --accent: var(--brand-accent-500); --muted:#9FB5AF;
+  --bg: var(--brand-emerald-900); --fg:#FAF9F6; --card:var(--brand-emerald-700); --border:var(--brand-mint-200);
+  --primary: var(--brand-accent-500); --primary-strong: var(--brand-rose-300); --muted:var(--brand-mint-200);
 
   --ff-ui:'Inter',system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
   --ff-title:'Space Grotesk',var(--ff-ui);
@@ -28,7 +33,7 @@ a{color:inherit;text-decoration:none}
   --fs-body:1rem; --fs-sm:.95rem; --fs-xs:.875rem; --lh-tight:1.15; --lh-normal:1.6;
 
   --radius-sm:8px; --radius-md:14px; --radius-lg:24px; --radius-pill:9999px;
-  --shadow-1:0 8px 24px rgba(0,0,0,.14); --shadow-2:0 12px 32px rgba(0,0,0,.18);
+  --shadow-1:0 8px 24px rgba(0,51,50,.14); --shadow-2:0 12px 32px rgba(0,51,50,.18);
 
   --ease-smooth:cubic-bezier(.22,.61,.36,1);
   --dur-fast:160ms; --dur-med:220ms; --dur-slow:320ms;
@@ -37,10 +42,10 @@ a{color:inherit;text-decoration:none}
   --header-h: 64px;
 }
 
-/* Thème clair (toggle) */
+/* Thème clair (Neo Sage) */
 html[data-theme="light"]{
-  --bg:#F6FBF9; --fg:#0f1f1b; --card:#ffffff; --border:#d9e6e1;
-  --primary:#0f7a67; --primary-strong:#0a5d4e; --muted:#5b6a65;
+  --bg:#D4C5B1; --fg:#2E2E2E; --card:#FAF9F6; --border:#E6E6E6;
+  --primary:#8A9A5B; --primary-strong:#A8C3BC; --muted:#4A4A4A;
 }
 
 /* === Layout === */
@@ -64,8 +69,8 @@ p{line-height:var(--lh-normal);margin:0 0 16px;font-size:var(--fs-body)}
 .site-header{position:sticky;top:0;z-index:50;background:color-mix(in srgb, var(--bg) 82%, transparent);backdrop-filter:saturate(1.3) blur(8px);border-bottom:1px solid var(--border)}
 .header-inner.grid-3{
   display:grid;
-  grid-template-columns: auto 1fr auto;
-  align-items:center;          /* centre verticalement les 3 colonnes */
+  grid-template-columns:auto 1fr auto;
+  align-items:center;
   gap:12px;
   height:var(--header-h);
   padding:0;
@@ -75,23 +80,23 @@ p{line-height:var(--lh-normal);margin:0 0 16px;font-size:var(--fs-body)}
 .nav,
 .header-actions{
   display:flex;
-  align-items:center;          /* centre le contenu */
-  height:var(--header-h);      /* même boîte de 64px pour les 3 colonnes */
+  align-items:center;
+  height:var(--header-h);
   line-height:1;
 }
 
-.logo{font-family:var(--ff-title);font-weight:700;letter-spacing:.02em;background:linear-gradient(90deg,var(--brand-rose-300),var(--brand-mint-200));-webkit-background-clip:text;background-clip:text;color:transparent;font-size:1.25rem;justify-self:center;display:flex;align-items:center;}
+.logo{font-family:var(--ff-title);font-weight:700;letter-spacing:.02em;background:linear-gradient(90deg,var(--brand-rose-300),var(--brand-mint-200));-webkit-background-clip:text;background-clip:text;color:transparent;font-size:1.25rem;justify-self:center;grid-column:2;}
 
 /* nav list */
-.nav{justify-self:start;align-self:center;display:flex;align-items:center}
+.nav{justify-self:start;align-self:center;display:flex;align-items:center;grid-column:1;}
 .nav-list{
   list-style:none;
   margin:0;
   padding:0;
-  display:flex;
+  display:none;
   align-items:center;
   gap:clamp(.25rem,.8vw,.6rem);
-  height: 100%;
+  height:100%;
 }
 .nav-list a{
   display:flex;
@@ -174,6 +179,13 @@ p{line-height:var(--lh-normal);margin:0 0 16px;font-size:var(--fs-body)}
   .nav-list{display:flex;gap:clamp(.25rem,.8vw,.6rem);flex-wrap:wrap;overflow:visible}
 }
 
+@media (min-width:900px){
+  body.no-desktop-nav .nav{display:none}
+  body.no-desktop-nav .header-inner.grid-3{grid-template-columns:1fr auto}
+  body.no-desktop-nav .logo{grid-column:1;justify-self:start}
+  body.no-desktop-nav .header-actions{grid-column:2;justify-self:end}
+}
+
 /* Mobile dropdown */
 .nav-open #primary-nav{display:flex;flex-direction:column;gap:.25rem;position:absolute;left:16px;top:60px;background:var(--card);border:1px solid var(--border);border-radius:14px;padding:.5rem;box-shadow:var(--shadow-2);max-width:calc(100% - 32px)}
 
@@ -181,7 +193,7 @@ p{line-height:var(--lh-normal);margin:0 0 16px;font-size:var(--fs-body)}
 .hero{position:relative;min-height:var(--hero-min);display:grid;place-items:center;overflow:hidden}
 #bg-canvas{position:absolute;inset:0;width:100%;height:100%}
 .hero-inner{position:relative;text-align:center;z-index:1;padding:40px 0}
-.hero-sub{max-width:60ch;margin-inline:auto;color:#EEF3F1}
+.hero-sub{max-width:60ch;margin-inline:auto;color:var(--muted)}
 
 /* === Highlights === */
 #highlights{margin-top:-20px}
@@ -202,16 +214,16 @@ p{line-height:var(--lh-normal);margin:0 0 16px;font-size:var(--fs-body)}
 .skill-badges{display:grid;gap:.5rem;padding:0;margin:0;list-style:none}
 .skill-badges li{display:flex;align-items:center;justify-content:space-between;background:var(--card);border:1px solid var(--border);border-radius:8px;padding:.5rem .75rem}
 meter{width:46%;height:12px}
-meter::-webkit-meter-bar{background:color-mix(in srgb, var(--card), white 8%);border-radius:999px}
-meter::-webkit-meter-optimum-value{background:linear-gradient(90deg,var(--brand-accent-500), var(--emerald-600));border-radius:999px}
-meter:-moz-meter-optimum::-moz-meter-bar{background:linear-gradient(90deg,var(--brand-accent-500), var(--emerald-600))}
+meter::-webkit-meter-bar{background:color-mix(in srgb, var(--card), var(--fg) 8%);border-radius:999px}
+meter::-webkit-meter-optimum-value{background:linear-gradient(90deg,var(--brand-accent-500), var(--brand-emerald-700));border-radius:999px}
+meter:-moz-meter-optimum::-moz-meter-bar{background:linear-gradient(90deg,var(--brand-accent-500), var(--brand-emerald-700))}
 
 /* === Projects === */
 .section-head{display:flex;flex-wrap:wrap;gap:1rem;align-items:center;justify-content:space-between;margin-bottom:24px}
 .filters{display:flex;gap:.5rem;flex-wrap:wrap}
 .chip{border:1px solid var(--border);background:transparent;border-radius:9999px;padding:.35rem .75rem;transition:transform var(--dur-fast) var(--ease-smooth), background var(--dur-fast)}
 .chip:hover{background:color-mix(in srgb, var(--card), transparent 30%)}
-.chip.is-active{background:var(--primary);border-color:var(--primary);color:white}
+.chip.is-active{background:var(--primary);border-color:var(--primary);color:#FAF9F6}
 .grid{display:grid;grid-template-columns:1fr;gap:16px}
 @media (min-width: 720px){.grid{grid-template-columns:repeat(2,1fr)}}
 @media (min-width: 1024px){.grid{grid-template-columns:repeat(3,1fr)}}
@@ -221,17 +233,17 @@ meter:-moz-meter-optimum::-moz-meter-bar{background:linear-gradient(90deg,var(--
 .project-media{height:140px;border-radius:8px;
   background:
     linear-gradient(180deg,var(--brand-blush-100),var(--brand-rose-300),var(--brand-accent-500)),
-    repeating-linear-gradient(45deg, rgba(0,0,0,.06) 0, rgba(0,0,0,.06) 12px, transparent 12px, transparent 24px);
+    repeating-linear-gradient(45deg, rgba(0,51,50,.06) 0, rgba(0,51,50,.06) 12px, transparent 12px, transparent 24px);
   position:relative;overflow:hidden;margin-bottom:12px}
 .project-media::before{content:attr(data-badge);position:absolute;right:12px;bottom:10px;font-weight:700;opacity:.9}
 .project-media::after{content:"BR";position:absolute;left:12px;top:10px;font-family:var(--ff-title);font-weight:700;opacity:.09;font-size:48px;letter-spacing:2px}
-.project-card .overlay{position:absolute;inset:0;border-radius:inherit;display:flex;align-items:flex-end;justify-content:flex-end;padding:16px;opacity:0;transition:opacity var(--dur-med);background:linear-gradient(180deg, transparent 50%, rgba(0,0,0,.35))}
+.project-card .overlay{position:absolute;inset:0;border-radius:inherit;display:flex;align-items:flex-end;justify-content:flex-end;padding:16px;opacity:0;transition:opacity var(--dur-med);background:linear-gradient(180deg, transparent 50%, rgba(0,51,50,.35))}
 .project-card:hover .overlay{opacity:1}
 
 /* Modal */
 .modal{position:fixed;inset:0;display:none;place-items:center}
 .modal[aria-hidden="false"]{display:grid}
-.modal-backdrop{position:absolute;inset:0;background:rgba(0,0,0,.45)}
+.modal-backdrop{position:absolute;inset:0;background:rgba(0,51,50,.45)}
 .modal-dialog{position:relative;z-index:1;max-width:760px;margin:0;background:var(--card);border:1px solid var(--border);border-radius:24px;padding:24px}
 .modal-close{position:absolute;right:8px;top:8px;border:1px solid var(--border);background:transparent;border-radius:8px;padding:.25rem .5rem}
 
@@ -246,7 +258,7 @@ meter:-moz-meter-optimum::-moz-meter-bar{background:linear-gradient(90deg,var(--
 input,textarea,select{background:var(--card);border:1px solid var(--border);border-radius:8px;padding:.6rem .75rem}
 select{-webkit-appearance:none;-moz-appearance:none;appearance:none}
 input:focus,textarea:focus,select:focus{border-color:var(--primary)}
-.contact-form select{background:var(--card) url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2010%206'%3E%3Cpath%20fill='%239FB5AF'%20d='M0%200l5%206%205-6z'/%3E%3C/svg%3E") no-repeat right .75rem center/12px 8px;padding-right:2.5rem}
+  .contact-form select{background:var(--card) url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2010%206'%3E%3Cpath%20fill='%23BDCDCF'%20d='M0%200l5%206%205-6z'/%3E%3C/svg%3E") no-repeat right .75rem center/12px 8px;padding-right:2.5rem}
 .contact-form .w-35{flex:0 0 35%}
 .contact-form .w-40{flex:0 0 40%}
 .contact-form .w-55{flex:0 0 55%}
@@ -277,13 +289,13 @@ input:focus,textarea:focus,select:focus{border-color:var(--primary)}
 
 /* Buttons / cursor */
 .btn{display:inline-flex;align-items:center;justify-content:center;gap:.5rem;border-radius:9999px;padding:.6rem 1rem;border:1px solid var(--border);transition:transform var(--dur-fast) var(--ease-smooth), background var(--dur-fast)}
-.btn.primary{background:var(--primary);border-color:var(--primary);color:#fff}
+.btn.primary{background:var(--primary);border-color:var(--primary);color:#FAF9F6}
 .btn.primary:hover{background:var(--primary-strong)}
 .btn.secondary{background:var(--card)}
 .btn.ghost{background:transparent}
 .btn.icon{width:40px;height:40px;border-radius:50%}
 .btn:active{transform:none}
-#cursor{position:fixed;pointer-events:none;width:18px;height:18px;border:2px solid color-mix(in srgb, var(--accent), transparent 30%);border-radius:50%;transform:translate(-50%,-50%);opacity:0;transition:opacity var(--dur-fast);z-index:1000}
+#cursor{position:fixed;pointer-events:none;width:18px;height:18px;border:2px solid color-mix(in srgb, var(--primary), transparent 30%);border-radius:50%;transform:translate(-50%,-50%);opacity:0;transition:opacity var(--dur-fast);z-index:1000}
 
 /* Reduced motion */
 @media (prefers-reduced-motion: reduce){*{transition:none !important;animation:none !important}}

--- a/index.html
+++ b/index.html
@@ -24,11 +24,14 @@
   <script src="https://www.google.com/recaptcha/api.js?render=6LcrbygnAAAAAKvyMs6bpkC4jnoewlX0K8MPV6P5"></script>
 </head>
 <body>
+  <!-- Ajouter la classe "no-desktop-nav" sur <body> pour un en-tête sans navigation sur desktop -->
   <a class="skip-link" href="#main">Aller au contenu</a>
 
   <header class="site-header" role="banner">
     <div class="container header-inner grid-3">
-      <!-- Mobile: burger à gauche, logo centré, actions à droite | Desktop: logo gauche, nav milieu, actions droite -->
+      <!-- Mobile: burger à gauche, logo centré, langue à droite | Desktop: logo gauche, nav centre, actions droite -->
+      <a class="logo" href="#accueil" aria-label="Retour à l’accueil"><span aria-hidden="true">BR</span></a>
+
       <nav class="nav" aria-label="Navigation principale">
         <button class="nav-toggle strawberry" aria-expanded="false" aria-controls="primary-nav" aria-label="Ouvrir le menu">
           <span class="line l1"></span><span class="line l2"></span><span class="line l3"></span>
@@ -42,8 +45,6 @@
           <li><a data-i18n="nav.contact" href="#contact">Contact</a></li>
         </ul>
       </nav>
-
-      <a class="logo" href="#accueil" aria-label="Retour à l’accueil"><span aria-hidden="true">BR</span></a>
 
       <div class="header-actions">
         <button id="themeToggle" class="btn icon" aria-label="Changer de thème">🌓</button>

--- a/legal.html
+++ b/legal.html
@@ -6,15 +6,22 @@
   <title>Mentions légales — Benjamin Reuland</title>
   <meta name="description" content="Mentions légales et politique de confidentialité du site benjamin-reuland.be." />
   <link rel="icon" href="/assets/img/favicon.svg" type="image/svg+xml">
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Space+Grotesk:wght@600;700&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="/assets/css/styles.css" />
 </head>
 <body>
+  <!-- Ajouter la classe "no-desktop-nav" sur <body> pour un en-tête sans navigation sur desktop -->
   <a class="skip-link" href="#main">Aller au contenu</a>
   <header class="site-header" role="banner">
     <div class="container header-inner grid-3">
       <a class="logo" href="/" aria-label="Retour à l’accueil"><span aria-hidden="true">BR</span></a>
       <nav class="nav" aria-label="Navigation principale">
-        <ul class="nav-list nav-legal">
+        <button class="nav-toggle strawberry" aria-expanded="false" aria-controls="primary-nav" aria-label="Ouvrir le menu">
+          <span class="line l1"></span><span class="line l2"></span><span class="line l3"></span>
+        </button>
+        <ul id="primary-nav" class="nav-list">
           <li><a href="/">Accueil</a></li>
           <li><a href="/#a-propos">À propos</a></li>
           <li><a href="/#services">Services</a></li>
@@ -22,7 +29,15 @@
         </ul>
       </nav>
       <div class="header-actions">
-        <a class="btn icon" href="/"><span aria-hidden="true">←</span></a>
+        <button id="themeToggle" class="btn icon" aria-label="Changer de thème">🌓</button>
+        <label for="langSelect" class="sr-only">Langue</label>
+        <select id="langSelect" class="lang-select" aria-label="Changer de langue">
+          <option value="fr" selected>FR</option>
+          <option value="en">EN</option>
+          <option value="de">DE</option>
+          <option value="nl">NL</option>
+          <option value="se">SE</option>
+        </select>
       </div>
     </div>
   </header>
@@ -70,6 +85,6 @@
       <p class="rights">© <span id="year"></span> Benjamin Reuland. Tous droits réservés.</p>
     </div>
   </footer>
-  <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
+  <script type="module" src="/assets/js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- overhaul header for mobile and desktop with strawberry toggle and optional nav-less layout
- adopt new Gradient dark and Neo Sage light palettes with theme-aware selection colors
- sync legal page with new header and shared scripts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f584d0c708326812816cd1e032805